### PR TITLE
Update dev scripts: add frontend-only and fix backend PYTHONPATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:frontend\" \"npm run dev:backend\"",
     "dev:frontend": "cd frontend && npm run dev",
+    "dev:frontend-only": "cd frontend && npm run dev",
     "dev:backend": "cd backend && PYTHONPATH=venv/lib/python3.11/site-packages:venv/lib64/python3.11/site-packages python3 main.py",
     "install:all": "npm run install:frontend && npm run install:backend",
     "install:frontend": "cd frontend && npm install",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:frontend\" \"npm run dev:backend\"",
     "dev:frontend": "cd frontend && npm run dev",
-    "dev:backend": "cd backend && ./venv/bin/python main.py",
+    "dev:backend": "cd backend && PYTHONPATH=venv/lib/python3.11/site-packages:venv/lib64/python3.11/site-packages python3 main.py",
     "install:all": "npm run install:frontend && npm run install:backend",
     "install:frontend": "cd frontend && npm install",
     "install:backend": "cd backend && python3 -m pip install -r requirements.txt",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:frontend\" \"npm run dev:backend\"",
     "dev:frontend": "cd frontend && npm run dev",
-    "dev:backend": "cd backend && python3 main.py",
+    "dev:backend": "cd backend && ./venv/bin/python main.py",
     "install:all": "npm run install:frontend && npm run install:backend",
     "install:frontend": "cd frontend && npm install",
     "install:backend": "cd backend && python3 -m pip install -r requirements.txt",


### PR DESCRIPTION
## Changes Made

This pull request updates the development scripts in `package.json`:

### Script Additions
- **Added `dev:frontend-only`**: New script that runs only the frontend development server by executing `cd frontend && npm run dev`

### Script Modifications
- **Updated `dev:backend`**: Modified the backend development script to include `PYTHONPATH` environment variable configuration
  - Added `PYTHONPATH=venv/lib/python3.11/site-packages:venv/lib64/python3.11/site-packages` before the Python command
  - This ensures the virtual environment packages are properly accessible when running the backend

### Files Modified
- `package.json`: Updated scripts section with the new and modified development commandsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c34eb244cea2477fbed1acec912d07b5/curry-world)

👀 [Preview Link](https://c34eb244cea2477fbed1acec912d07b5-curry-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c34eb244cea2477fbed1acec912d07b5</projectId>-->
<!--<branchName>curry-world</branchName>-->