### PR TITLE
Fix capitalization and add work/education migrations

### DIFF
--- a/backend/init_database.py
+++ b/backend/init_database.py
@@ -25,7 +25,9 @@ try:
     from app.models.friendship import Friendship
     from app.models.profile_view import ProfileView
     from app.models.notification import Notification
-    
+    from app.models.work_experience import WorkExperience
+    from app.models.education import Education
+
     print("✅ Modelos importados!")
     
     # Listar tabelas que serão criadas

--- a/backend/main.py
+++ b/backend/main.py
@@ -69,6 +69,14 @@ async def lifespan(app: FastAPI):
             print("✅ Migration post_public_id applied")
         except Exception as me:
             print(f"⚠️ Migration post_public_id failed or skipped: {me}")
+        try:
+            from migrate_work_education import migrate_work_education
+            if migrate_work_education():
+                print("✅ Migration work_education applied")
+            else:
+                print("⚠️ Migration work_education returned False (possibly already migrated)")
+        except Exception as me:
+            print(f"⚠️ Migration work_education failed or skipped: {me}")
     except Exception as e:
         print(f"❌ Error creating database tables: {e}")
     yield

--- a/frontend/src/components/MultipleWorkEducationModal.jsx
+++ b/frontend/src/components/MultipleWorkEducationModal.jsx
@@ -452,7 +452,7 @@ const MultipleWorkEducationModal = ({
                   <div className="flex items-center space-x-3">
                     <Briefcase size={20} className="text-gray-500" />
                     <div>
-                      <p className="font-medium text-gray-900">Informações de Trabalho</p>
+                      <p className="font-medium text-gray-900">Informações de trabalho</p>
                       <p className="text-sm text-gray-600">Experiências profissionais e cargo atual</p>
                     </div>
                   </div>
@@ -472,7 +472,7 @@ const MultipleWorkEducationModal = ({
                   <div className="flex items-center space-x-3">
                     <GraduationCap size={20} className="text-gray-500" />
                     <div>
-                      <p className="font-medium text-gray-900">Informações de Educação</p>
+                      <p className="font-medium text-gray-900">Informações de educação</p>
                       <p className="text-sm text-gray-600">Formação acadêmica e cursos</p>
                     </div>
                   </div>
@@ -492,7 +492,7 @@ const MultipleWorkEducationModal = ({
                   <div className="flex items-center space-x-3">
                     <MapPin size={20} className="text-gray-500" />
                     <div>
-                      <p className="font-medium text-gray-900">Informações de Localização</p>
+                      <p className="font-medium text-gray-900">Informações de localização</p>
                       <p className="text-sm text-gray-600">Cidade atual e cidade natal</p>
                     </div>
                   </div>

--- a/frontend/src/components/PersonalInfoEditModal.jsx
+++ b/frontend/src/components/PersonalInfoEditModal.jsx
@@ -640,7 +640,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
                 <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center space-x-3">
                     <Briefcase size={16} className="text-gray-500" />
-                    <span className="text-sm font-medium">Informações de Trabalho</span>
+                    <span className="text-sm font-medium">Informações de trabalho</span>
                   </div>
                   <button
                     onClick={() => handlePrivacyChange('showWorkInfo', !formData.privacy.showWorkInfo)}
@@ -653,7 +653,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
                 <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center space-x-3">
                     <GraduationCap size={16} className="text-gray-500" />
-                    <span className="text-sm font-medium">Informações de Educa��ão</span>
+                    <span className="text-sm font-medium">Informações de educação</span>
                   </div>
                   <button
                     onClick={() => handlePrivacyChange('showEducationInfo', !formData.privacy.showEducationInfo)}
@@ -666,7 +666,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
                 <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center space-x-3">
                     <MapPin size={16} className="text-gray-500" />
-                    <span className="text-sm font-medium">Informações de Localização</span>
+                    <span className="text-sm font-medium">Informações de localização</span>
                   </div>
                   <button
                     onClick={() => handlePrivacyChange('showLocationInfo', !formData.privacy.showLocationInfo)}
@@ -679,7 +679,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
                 <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center space-x-3">
                     <Heart size={16} className="text-gray-500" />
-                    <span className="text-sm font-medium">Informações de Relacionamento</span>
+                    <span className="text-sm font-medium">Informações de relacionamento</span>
                   </div>
                   <button
                     onClick={() => handlePrivacyChange('showRelationshipInfo', !formData.privacy.showRelationshipInfo)}
@@ -692,7 +692,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
                 <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center space-x-3">
                     <Phone size={16} className="text-gray-500" />
-                    <span className="text-sm font-medium">Informações de Contato</span>
+                    <span className="text-sm font-medium">Informações de contato</span>
                   </div>
                   <button
                     onClick={() => handlePrivacyChange('showContactInfo', !formData.privacy.showContactInfo)}

--- a/frontend/src/components/PersonalInfoEditModal.jsx
+++ b/frontend/src/components/PersonalInfoEditModal.jsx
@@ -183,7 +183,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
       <div className="bg-white h-full w-full flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
-          <h2 className="text-xl font-bold text-gray-900">Editar Informações Pessoais</h2>
+          <h2 className="text-xl font-bold text-gray-900">Editar informações pessoais</h2>
           <button
             onClick={onClose}
             className="p-2 hover:bg-gray-100 rounded-full transition-colors"

--- a/frontend/src/components/PersonalInfoEditModal.jsx
+++ b/frontend/src/components/PersonalInfoEditModal.jsx
@@ -124,10 +124,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
       } : undefined
     }
     try {
-      // 1) Salvar informações básicas
-      await onSave(payload)
-
-      // 2) Criar novas experiências de trabalho adicionadas no "+"
+      // 1) Criar novas experiências de trabalho primeiro
       const itemsToCreate = newWorkItems
         .map(i => ({ company: (i.company || '').trim(), position: (i.position || '').trim() }))
         .filter(i => i.company && i.position)
@@ -147,12 +144,17 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
         }
       }
 
+      // 2) Salvar informações básicas e permitir que o pai recarregue já com as novas experiências
+      await onSave(payload)
+
       // 3) Atualizar dados no modal para refletir criações
       try {
         const refreshed = await personalInfoAPI.get()
         setFormData(prev => ({
           ...prev,
-          work: refreshed.data?.personalInfo?.work || prev.work
+          work: refreshed.data?.personalInfo?.work || prev.work,
+          // útil para exibir contadores corretos dentro do modal após salvar
+          workExperiences: refreshed.data?.personalInfo?.workExperiences || prev.workExperiences
         }))
       } catch {}
 

--- a/frontend/src/components/ProfileEditModal.jsx
+++ b/frontend/src/components/ProfileEditModal.jsx
@@ -369,7 +369,7 @@ const ProfileEditModal = ({ isOpen, onClose, onUpdated }) => {
             <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
               <p className="text-blue-800 text-sm">
                 💡 <strong>Dica:</strong> Para editar informações detalhadas de trabalho, educação e outras informações pessoais, 
-                use o botão "Editar" na seção "Informações Pessoais" do seu perfil.
+                use o botão "Editar" na seção "Informações pessoais" do seu perfil.
               </p>
             </div>
           </div>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1312,7 +1312,7 @@ const Profile = () => {
           <div className="flex items-center justify-between mb-3">
             <h3 className="font-semibold text-gray-800 flex items-center">
               <Users size={18} className="mr-2" />
-              Informações Pessoais
+              Informações pessoais
             </h3>
             {!viewAsVisitor && (
               <button


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two main issues:
1. **Capitalization standardization**: Users reported inconsistent capitalization in section titles throughout the social network, specifically "Informações Pessoais" should be "Informações pessoais" with proper Portuguese capitalization rules
2. **Work experience display**: Users noted that only the first job position was showing in profiles, with additional positions/organizations not being passed to the frontend

## Code changes

### Frontend capitalization fixes
- Updated all section titles to use proper Portuguese capitalization (lowercase after first word)
- Changed "Informações Pessoais" to "Informações pessoais" across multiple components
- Applied consistent capitalization to work, education, location, relationship, and contact information sections
- Updated modal titles and privacy settings labels

### Backend database improvements  
- Added missing imports for `WorkExperience` and `Education` models in database initialization
- Added new migration system for work and education data (`migrate_work_education`)
- Enhanced migration handling with proper error catching and status reporting

### Frontend data handling improvements
- Improved work experience creation flow in PersonalInfoEditModal
- Added proper data refresh after saving new work experiences
- Enhanced error handling and data synchronization between modal and profile displayTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7129bb91c48346a7b5c7e15b449b0c3e/glow-oasis)

👀 [Preview Link](https://7129bb91c48346a7b5c7e15b449b0c3e-glow-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7129bb91c48346a7b5c7e15b449b0c3e</projectId>-->
<!--<branchName>glow-oasis</branchName>-->