### PR TITLE
Add database migration for multiple work/education entries

### DIFF
--- a/backend/scripts/migrate_all.py
+++ b/backend/scripts/migrate_all.py
@@ -56,6 +56,87 @@ def _ensure_optional_columns():
         if not _has_col(conn, 'messages', 'media_mime'):
             conn.execute(text("ALTER TABLE messages ADD COLUMN media_mime TEXT"))
 
+def _ensure_work_education_tables():
+    """Ensure tables and essential columns/indexes for multiple work/education entries (SQLite-safe)."""
+    with engine.begin() as conn:
+        # Work experiences table
+        conn.execute(text(
+            """
+            CREATE TABLE IF NOT EXISTS work_experiences (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                company TEXT NOT NULL,
+                position TEXT NOT NULL,
+                description TEXT,
+                start_date DATE,
+                end_date DATE,
+                is_current BOOLEAN DEFAULT 0,
+                order_index INTEGER DEFAULT 0,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        ))
+        # Add missing columns if table already existed
+        if not _has_col(conn, 'work_experiences', 'description'):
+            conn.execute(text("ALTER TABLE work_experiences ADD COLUMN description TEXT"))
+        if not _has_col(conn, 'work_experiences', 'start_date'):
+            conn.execute(text("ALTER TABLE work_experiences ADD COLUMN start_date DATE"))
+        if not _has_col(conn, 'work_experiences', 'end_date'):
+            conn.execute(text("ALTER TABLE work_experiences ADD COLUMN end_date DATE"))
+        if not _has_col(conn, 'work_experiences', 'is_current'):
+            conn.execute(text("ALTER TABLE work_experiences ADD COLUMN is_current BOOLEAN DEFAULT 0"))
+        if not _has_col(conn, 'work_experiences', 'order_index'):
+            conn.execute(text("ALTER TABLE work_experiences ADD COLUMN order_index INTEGER DEFAULT 0"))
+        if not _has_col(conn, 'work_experiences', 'created_at'):
+            conn.execute(text("ALTER TABLE work_experiences ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP"))
+        if not _has_col(conn, 'work_experiences', 'updated_at'):
+            conn.execute(text("ALTER TABLE work_experiences ADD COLUMN updated_at DATETIME DEFAULT CURRENT_TIMESTAMP"))
+        # Indexes
+        conn.execute(text("CREATE INDEX IF NOT EXISTS ix_work_experiences_user ON work_experiences(user_id)"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS ix_work_experiences_user_order_created ON work_experiences(user_id, order_index DESC, created_at DESC)"))
+
+        # Education table
+        conn.execute(text(
+            """
+            CREATE TABLE IF NOT EXISTS education (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                institution TEXT NOT NULL,
+                degree TEXT NOT NULL,
+                field TEXT,
+                description TEXT,
+                start_date DATE,
+                end_date DATE,
+                is_current BOOLEAN DEFAULT 0,
+                order_index INTEGER DEFAULT 0,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        ))
+        # Add missing columns
+        if not _has_col(conn, 'education', 'field'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN field TEXT"))
+        if not _has_col(conn, 'education', 'description'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN description TEXT"))
+        if not _has_col(conn, 'education', 'start_date'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN start_date DATE"))
+        if not _has_col(conn, 'education', 'end_date'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN end_date DATE"))
+        if not _has_col(conn, 'education', 'is_current'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN is_current BOOLEAN DEFAULT 0"))
+        if not _has_col(conn, 'education', 'order_index'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN order_index INTEGER DEFAULT 0"))
+        if not _has_col(conn, 'education', 'created_at'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP"))
+        if not _has_col(conn, 'education', 'updated_at'):
+            conn.execute(text("ALTER TABLE education ADD COLUMN updated_at DATETIME DEFAULT CURRENT_TIMESTAMP"))
+        # Indexes
+        conn.execute(text("CREATE INDEX IF NOT EXISTS ix_education_user ON education(user_id)"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS ix_education_user_order_created ON education(user_id, order_index DESC, created_at DESC)"))
+
+
 def _migrate_public_profile_id(db):
     # add column
     if not _has_col(db, 'users', 'public_profile_id'):

--- a/backend/scripts/migrate_all.py
+++ b/backend/scripts/migrate_all.py
@@ -343,6 +343,8 @@ def migrate_all() -> bool:
         Base.metadata.create_all(bind=engine)
         # 2) Ensure optional columns
         _ensure_optional_columns()
+        # 2b) Ensure work/education tables and columns for multiple entries
+        _ensure_work_education_tables()
         # 3) Data/ID migrations
         db = SessionLocal()
         try:

--- a/frontend/src/components/PersonalInfoEditModal.jsx
+++ b/frontend/src/components/PersonalInfoEditModal.jsx
@@ -124,11 +124,27 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
       } : undefined
     }
     try {
-      // 1) Criar novas experiências de trabalho primeiro
-      const itemsToCreate = newWorkItems
+      // 1) Criar experiências de trabalho (inclui o cargo principal e os adicionais), evitando duplicados
+      const existing = await workExperienceAPI.getAll().then(r => r.data || []).catch(() => [])
+      const existingKeys = new Set(existing.map(e => `${(e.position || '').trim().toLowerCase()}::${(e.company || '').trim().toLowerCase()}`))
+
+      const toCreate = []
+      const mainCompany = (formData.work?.company || '').trim()
+      const mainPosition = (formData.work?.position || '').trim()
+      if (mainCompany && mainPosition) {
+        const key = `${mainPosition.toLowerCase()}::${mainCompany.toLowerCase()}`
+        if (!existingKeys.has(key)) toCreate.push({ company: mainCompany, position: mainPosition })
+      }
+      const additional = newWorkItems
         .map(i => ({ company: (i.company || '').trim(), position: (i.position || '').trim() }))
         .filter(i => i.company && i.position)
-      for (const item of itemsToCreate) {
+      for (const item of additional) {
+        const key = `${item.position.toLowerCase()}::${item.company.toLowerCase()}`
+        if (!existingKeys.has(key)) toCreate.push(item)
+      }
+
+      let baseOrder = Array.isArray(existing) ? existing.length : 0
+      for (const item of toCreate) {
         try {
           await workExperienceAPI.create({
             company: item.company,
@@ -137,7 +153,7 @@ const PersonalInfoEditModal = ({ isOpen, onClose, personalInfo, onSave }) => {
             start_date: null,
             end_date: null,
             is_current: false,
-            order_index: 0
+            order_index: baseOrder++
           })
         } catch (e) {
           console.warn('Falha ao criar experiência de trabalho:', e?.response?.data || e.message)

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1450,22 +1450,28 @@ const Profile = () => {
             {/* Experiência de trabalho - primeira das múltiplas ou campo simples */}
             {personalInfo?.privacy?.showWorkInfo && (
               <div className="space-y-2">
-                {personalInfo?.work?.displayText && (
-                  <div className="flex items-center text-sm text-gray-600">
-                    <Briefcase size={16} className="mr-3 text-gray-500" />
-                    <span>{personalInfo.work.displayText}</span>
-                  </div>
-                )}
-                {personalInfo?.workExperiences && personalInfo.workExperiences.length > 0 && (
-                  <>
-                    {personalInfo.workExperiences.map((we, idx) => (
-                      <div key={we.id || idx} className="flex items-center text-sm text-gray-600">
-                        <Briefcase size={16} className="mr-3 text-gray-500" />
-                        <span>{we.displayText || [we.position, we.company].filter(Boolean).join(' • ')}</span>
-                      </div>
-                    ))}
-                  </>
-                )}
+                {(() => {
+                  const base = []
+                  if (personalInfo?.work && (personalInfo.work.position || personalInfo.work.company || personalInfo.work.displayText)) {
+                    base.push(personalInfo.work)
+                  }
+                  if (Array.isArray(personalInfo?.workExperiences)) {
+                    base.push(...personalInfo.workExperiences)
+                  }
+                  const seen = new Set()
+                  const items = base.filter(Boolean).filter((it) => {
+                    const key = `${(it.position || '').toLowerCase()}::${(it.company || '').toLowerCase()}::${it.displayText || ''}`
+                    if (seen.has(key)) return false
+                    seen.add(key)
+                    return true
+                  })
+                  return items.map((we, idx) => (
+                    <div key={we.id || idx} className="flex items-center text-sm text-gray-600">
+                      <Briefcase size={16} className="mr-3 text-gray-500" />
+                      <span>{we.displayText || [we.position, we.company].filter(Boolean).join(' • ')}</span>
+                    </div>
+                  ))
+                })()}
               </div>
             )}
 

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -221,7 +221,7 @@ const Profile = () => {
           ...prev,
           name: 'Marina Santos',
           username: 'marina_santos',
-          bio: '✨ UX Designer apaixonada por criar experiências incríveis\n��� Formada em Design Digital pela UFPE\n������� Atualmente trabalhando na @TechCorp\n📍 Recife, PE | 🇧🇷\n💕 Em um relacionamento com Jo��o Silva\n🎯 "Design is not just what it looks like - design is how it works"',
+          bio: '✨ UX Designer apaixonada por criar experiências incríveis\n🎨 Formada em Design Digital pela UFPE\n������� Atualmente trabalhando na @TechCorp\n📍 Recife, PE | 🇧🇷\n💕 Em um relacionamento com Jo��o Silva\n🎯 "Design is not just what it looks like - design is how it works"',
           isVerified: true,
           avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b786?w=400&h=400&fit=crop&crop=face',
           coverPhoto: 'https://images.unsplash.com/photo-1579952363873-27d3bfad9c0d?w=1200&h=400&fit=crop',
@@ -297,7 +297,7 @@ const Profile = () => {
               avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b786?w=400&h=400&fit=crop&crop=face',
               isVerified: true
             },
-            content: 'Workshop de Design Thinking hoje foi incrível! 🚀 Compartilhar conhecimento com outros designers me energiza muito. Próximo evento já está sendo planejado!',
+            content: 'Workshop de Design Thinking hoje foi incrível! 🚀 Compartilhar conhecimento com outros designers me energiza muito. Próximo evento já est�� sendo planejado!',
             imageUrl: 'https://images.unsplash.com/photo-1552664730-d307ca884978?w=600&h=400&fit=crop',
             createdAt: '2024-01-12T14:20:00Z',
             likes: 234,
@@ -842,7 +842,7 @@ const Profile = () => {
         const res = await personalInfoAPI.get()
         setPersonalInfo(res.data.personalInfo)
       } catch (e) {
-        console.warn('Não foi possível recarregar informações pessoais após salvar:', e?.response?.data || e.message)
+        console.warn('Não foi possível recarregar informaç��es pessoais após salvar:', e?.response?.data || e.message)
       }
       setUploadSuccess('Informa��ões pessoais atualizadas com sucesso!')
 
@@ -1448,19 +1448,24 @@ const Profile = () => {
           </div>
           <div className="space-y-3">
             {/* Experiência de trabalho - primeira das múltiplas ou campo simples */}
-            {personalInfo?.workExperiences && personalInfo.workExperiences.length > 0 && personalInfo.privacy?.showWorkInfo ? (
+            {personalInfo?.privacy?.showWorkInfo && (
               <div className="space-y-2">
-                {personalInfo.workExperiences.map((we, idx) => (
-                  <div key={we.id || idx} className="flex items-center text-sm text-gray-600">
+                {personalInfo?.work?.displayText && (
+                  <div className="flex items-center text-sm text-gray-600">
                     <Briefcase size={16} className="mr-3 text-gray-500" />
-                    <span>{we.displayText || [we.position, we.company].filter(Boolean).join(' • ')}</span>
+                    <span>{personalInfo.work.displayText}</span>
                   </div>
-                ))}
-              </div>
-            ) : personalInfo?.work?.displayText && personalInfo.privacy?.showWorkInfo && (
-              <div className="flex items-center text-sm text-gray-600">
-                <Briefcase size={16} className="mr-3 text-gray-500" />
-                <span>{personalInfo.work.displayText}</span>
+                )}
+                {personalInfo?.workExperiences && personalInfo.workExperiences.length > 0 && (
+                  <>
+                    {personalInfo.workExperiences.map((we, idx) => (
+                      <div key={we.id || idx} className="flex items-center text-sm text-gray-600">
+                        <Briefcase size={16} className="mr-3 text-gray-500" />
+                        <span>{we.displayText || [we.position, we.company].filter(Boolean).join(' • ')}</span>
+                      </div>
+                    ))}
+                  </>
+                )}
               </div>
             )}
 

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -221,7 +221,7 @@ const Profile = () => {
           ...prev,
           name: 'Marina Santos',
           username: 'marina_santos',
-          bio: '✨ UX Designer apaixonada por criar experiências incríveis\n🎨 Formada em Design Digital pela UFPE\n������� Atualmente trabalhando na @TechCorp\n📍 Recife, PE | 🇧🇷\n💕 Em um relacionamento com Jo��o Silva\n🎯 "Design is not just what it looks like - design is how it works"',
+          bio: '✨ UX Designer apaixonada por criar experiências incríveis\n��� Formada em Design Digital pela UFPE\n������� Atualmente trabalhando na @TechCorp\n📍 Recife, PE | 🇧🇷\n💕 Em um relacionamento com Jo��o Silva\n🎯 "Design is not just what it looks like - design is how it works"',
           isVerified: true,
           avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b786?w=400&h=400&fit=crop&crop=face',
           coverPhoto: 'https://images.unsplash.com/photo-1579952363873-27d3bfad9c0d?w=1200&h=400&fit=crop',
@@ -1449,14 +1449,13 @@ const Profile = () => {
           <div className="space-y-3">
             {/* Experiência de trabalho - primeira das múltiplas ou campo simples */}
             {personalInfo?.workExperiences && personalInfo.workExperiences.length > 0 && personalInfo.privacy?.showWorkInfo ? (
-              <div className="flex items-center text-sm text-gray-600">
-                <Briefcase size={16} className="mr-3 text-gray-500" />
-                <span>{personalInfo.workExperiences[0].displayText}</span>
-                {personalInfo.workExperiences.length > 1 && (
-                  <span className="ml-2 text-xs text-gray-400">
-                    +{personalInfo.workExperiences.length - 1} mais
-                  </span>
-                )}
+              <div className="space-y-2">
+                {personalInfo.workExperiences.map((we, idx) => (
+                  <div key={we.id || idx} className="flex items-center text-sm text-gray-600">
+                    <Briefcase size={16} className="mr-3 text-gray-500" />
+                    <span>{we.displayText || [we.position, we.company].filter(Boolean).join(' • ')}</span>
+                  </div>
+                ))}
               </div>
             ) : personalInfo?.work?.displayText && personalInfo.privacy?.showWorkInfo && (
               <div className="flex items-center text-sm text-gray-600">
@@ -1467,14 +1466,13 @@ const Profile = () => {
 
             {/* Formação acadêmica - primeira das múltiplas ou campo simples */}
             {personalInfo?.educationEntries && personalInfo.educationEntries.length > 0 && personalInfo.privacy?.showEducationInfo ? (
-              <div className="flex items-center text-sm text-gray-600">
-                <GraduationCap size={16} className="mr-3 text-gray-500" />
-                <span>{personalInfo.educationEntries[0].displayText}</span>
-                {personalInfo.educationEntries.length > 1 && (
-                  <span className="ml-2 text-xs text-gray-400">
-                    +{personalInfo.educationEntries.length - 1} mais
-                  </span>
-                )}
+              <div className="space-y-2">
+                {personalInfo.educationEntries.map((ed, idx) => (
+                  <div key={ed.id || idx} className="flex items-center text-sm text-gray-600">
+                    <GraduationCap size={16} className="mr-3 text-gray-500" />
+                    <span>{ed.displayText || [ed.degree, ed.institution].filter(Boolean).join(' • ')}</span>
+                  </div>
+                ))}
               </div>
             ) : personalInfo?.education?.displayText && personalInfo.privacy?.showEducationInfo && (
               <div className="flex items-center text-sm text-gray-600">


### PR DESCRIPTION
## Purpose

The user was experiencing issues with multiple work positions/roles not appearing in their profile. They could save additional positions, but only the first one was displaying in the frontend. The user requested a database migration script to properly support storing multiple work positions and education entries.

## Code changes

- **Backend migration script**: Added `_ensure_work_education_tables()` function to create `work_experiences` and `education` tables with proper schema including fields for company, position, description, dates, ordering, and timestamps
- **Database schema**: Added comprehensive column checks and indexes for both tables to ensure SQLite compatibility
- **Frontend profile display**: Updated profile component to properly render all work experiences and education entries instead of just showing the first one with a count
- **Display logic**: Enhanced the profile view to show each work/education entry individually with proper formatting and fallback display textTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 49`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f739ffdaf01646f6ae0107e0c7390cf5/cosmos-world)

👀 [Preview Link](https://f739ffdaf01646f6ae0107e0c7390cf5-cosmos-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f739ffdaf01646f6ae0107e0c7390cf5</projectId>-->
<!--<branchName>cosmos-world</branchName>-->