### PR TITLE
Improve audio chat icon and add direct send functionality

### DIFF
--- a/frontend/src/pages/Messages.jsx
+++ b/frontend/src/pages/Messages.jsx
@@ -86,6 +86,7 @@ const Messages = () => {
   const typingTimersRef = useRef({});
   const recIntervalRef = useRef(null);
   const ignoreOnStopRef = useRef(false);
+  const autoSendOnStopRef = useRef(false);
   const mediaStreamRef = useRef(null);
   const elapsedOffsetRef = useRef(0);
   const elapsedStartRef = useRef(0);
@@ -445,6 +446,13 @@ const Messages = () => {
           setPendingAudioBlob(null);
           return;
         }
+        if (autoSendOnStopRef.current) {
+          autoSendOnStopRef.current = false;
+          setIsRecording(false);
+          setIsPaused(false);
+          await sendAudioMessage(audioBlob);
+          return;
+        }
         setPendingAudioBlob(audioBlob);
         setIsRecording(false);
         setIsPaused(false);
@@ -460,6 +468,14 @@ const Messages = () => {
 
   const stopRecordingKeep = () => {
     if (mediaRecorderRef.current && isRecording) {
+      try { if (mediaRecorderRef.current.state === 'paused' && mediaRecorderRef.current.resume) mediaRecorderRef.current.resume(); } catch(e){}
+      mediaRecorderRef.current.stop();
+    }
+  };
+
+  const stopRecordingAndSend = () => {
+    if (mediaRecorderRef.current && isRecording) {
+      autoSendOnStopRef.current = true;
       try { if (mediaRecorderRef.current.state === 'paused' && mediaRecorderRef.current.resume) mediaRecorderRef.current.resume(); } catch(e){}
       mediaRecorderRef.current.stop();
     }
@@ -1047,8 +1063,8 @@ const Messages = () => {
                       <source src={URL.createObjectURL(pendingAudioBlob)} />
                     </audio>
                     <div className="flex w-full gap-2">
-                      <button onClick={sendPendingAudio} className="flex-1 bg-vibe-blue text-white px-4 py-2 rounded-lg">Enviar</button>
-                      <button onClick={cancelRecording} className="flex-1 bg-gray-100 text-gray-700 px-4 py-2 rounded-lg">Descartar</button>
+                      <button onClick={sendPendingAudio} className="flex-1 bg-vibe-blue text-white px-4 py-2 rounded-lg inline-flex items-center justify-center"><Send size={18} className="mr-2" />Enviar</button>
+                      <button onClick={cancelRecording} className="flex-1 bg-gray-100 text-gray-700 px-4 py-2 rounded-lg inline-flex items-center justify-center"><X size={18} className="mr-2" />Descartar</button>
                     </div>
                   </>
                 ) : isRecording ? (
@@ -1074,11 +1090,12 @@ const Messages = () => {
                       <X size={18} />
                     </button>
                     <button
-                      onClick={stopRecordingKeep}
-                      className="p-2 rounded-lg bg-vibe-blue text-white hover:bg-vibe-blue-dark"
-                      aria-label="Concluir gravação"
+                      onClick={stopRecordingAndSend}
+                      className="p-2 rounded-full bg-vibe-blue text-white hover:bg-vibe-blue-dark shadow-md"
+                      aria-label="Enviar áudio"
+                      title="Enviar áudio"
                     >
-                      <Square size={18} />
+                      <Send size={18} />
                     </button>
                   </div>
                 ) : null}
@@ -1119,17 +1136,20 @@ const Messages = () => {
 
                 <button
                   onClick={startRecording}
-                  className="hidden md:inline-flex items-center gap-2 bg-gray-100 text-gray-700 hover:bg-gray-200 px-3 py-2 rounded-lg flex-shrink-0"
+                  className="hidden md:inline-flex items-center gap-2 px-3 py-2 rounded-full bg-vibe-blue text-white hover:bg-vibe-blue-dark shadow-md flex-shrink-0"
+                  aria-label="Gravar áudio"
+                  title="Gravar áudio"
                 >
                   <Mic size={20} />
                   <span>Gravar áudio</span>
                 </button>
                 <button
                   onClick={startRecording}
-                  className="md:hidden p-2 rounded-lg flex-shrink-0 bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  className="md:hidden p-3 rounded-full flex-shrink-0 bg-vibe-blue text-white hover:bg-vibe-blue-dark shadow-md"
                   aria-label="Gravar áudio"
+                  title="Gravar áudio"
                 >
-                  <Mic size={20} />
+                  <Mic size={22} />
                 </button>
 
                 <button


### PR DESCRIPTION
## Purpose
The user requested improvements to the chat audio icon that produces and sends audio messages, aiming to enhance the user experience for voice messaging functionality.

## Code changes
- **Enhanced audio recording UI**: Updated recording button styling with rounded design, blue theme, and improved visual hierarchy
- **Added direct send functionality**: Implemented `stopRecordingAndSend()` function to allow immediate audio sending without preview
- **Improved button icons**: Added Send and X icons to audio control buttons for better visual clarity
- **Updated button styling**: Applied consistent blue theme, rounded corners, and shadow effects to audio-related buttons
- **Enhanced accessibility**: Added proper aria-labels and title attributes for better screen reader support
- **Auto-send mechanism**: Added `autoSendOnStopRef` to handle automatic sending when using the direct send buttonTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ba712bb9faa4418dbc716e3c6ba595d7/curry-sanctuary)

👀 [Preview Link](https://ba712bb9faa4418dbc716e3c6ba595d7-curry-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ba712bb9faa4418dbc716e3c6ba595d7</projectId>-->
<!--<branchName>curry-sanctuary</branchName>-->