### PR TITLE
Fix audio waveform background in chat bubbles

### DIFF
--- a/frontend/src/components/AudioWaveform.jsx
+++ b/frontend/src/components/AudioWaveform.jsx
@@ -38,8 +38,12 @@ export const LiveWaveform = ({ stream, height = 36, color = '#2563eb', bg = '#e5
 
     const draw = () => {
       analyser.getByteTimeDomainData(dataArray)
-      ctx2d.fillStyle = bg
-      ctx2d.fillRect(0, 0, canvas.width, canvas.height)
+      if (bg && bg !== 'transparent') {
+        ctx2d.fillStyle = bg
+        ctx2d.fillRect(0, 0, canvas.width, canvas.height)
+      } else {
+        ctx2d.clearRect(0, 0, canvas.width, canvas.height)
+      }
 
       // bars style to mimic popular chat UIs
       const barWidth = Math.max(2, Math.floor(canvas.width / 120))
@@ -163,8 +167,12 @@ export const PlaybackWaveform = ({ src, peaks, height = 36, color = '#2563eb', b
     }
 
     const drawBarsFromPeaks = (usePeaks) => {
-      ctx2d.fillStyle = bg
-      ctx2d.fillRect(0, 0, canvas.width, canvas.height)
+      if (bg && bg !== 'transparent') {
+        ctx2d.fillStyle = bg
+        ctx2d.fillRect(0, 0, canvas.width, canvas.height)
+      } else {
+        ctx2d.clearRect(0, 0, canvas.width, canvas.height)
+      }
       const centerY = Math.floor(canvas.height / 2)
       const n = Math.max(1, usePeaks?.length || 0)
       const barWidth = Math.max(2, Math.floor(canvas.width / Math.min(120, n)))
@@ -182,8 +190,12 @@ export const PlaybackWaveform = ({ src, peaks, height = 36, color = '#2563eb', b
     const drawAnalyser = () => {
       if (!analyserRef.current || !dataRef.current) return
       analyserRef.current.getByteTimeDomainData(dataRef.current)
-      ctx2d.fillStyle = bg
-      ctx2d.fillRect(0, 0, canvas.width, canvas.height)
+      if (bg && bg !== 'transparent') {
+        ctx2d.fillStyle = bg
+        ctx2d.fillRect(0, 0, canvas.width, canvas.height)
+      } else {
+        ctx2d.clearRect(0, 0, canvas.width, canvas.height)
+      }
 
       const barWidth = Math.max(2, Math.floor(canvas.width / 120))
       const gap = Math.max(1, Math.floor(barWidth * 0.6))

--- a/frontend/src/pages/Messages.jsx
+++ b/frontend/src/pages/Messages.jsx
@@ -1091,7 +1091,7 @@ const Messages = () => {
                         : 'bg-gray-200 text-gray-900'
                     }`}>
                       {message.messageType === 'audio' ? (
-                        <PlaybackWaveform src={message.mediaUrl} peaks={message.waveformPeaks} height={32} color={message.senderId === user.id ? '#ffffff' : '#2563eb'} bg={message.senderId === user.id ? 'rgba(255,255,255,0.2)' : '#e5e7eb'} />
+                        <PlaybackWaveform src={message.mediaUrl} peaks={message.waveformPeaks} height={32} color={message.senderId === user.id ? '#ffffff' : '#2563eb'} bg="transparent" />
                       ) : message.messageType === 'image' ? (
                         <img src={message.mediaUrl} alt="imagem" className="max-w-[240px] rounded-lg" />
                       ) : message.messageType === 'video' ? (


### PR DESCRIPTION
## Purpose

The user wanted to improve the audio message appearance in the chat to match popular messaging apps like WhatsApp and Messenger. The current audio player was displaying with a separate background that didn't integrate well with the chat bubble styling, creating visual inconsistency.

## Code changes

- **AudioWaveform.jsx**: Added transparent background support by checking if `bg` is 'transparent' and using `clearRect()` instead of `fillRect()` in three drawing functions (`LiveWaveform`, `PlaybackWaveform.drawBarsFromPeaks`, and `PlaybackWaveform.drawAnalyser`)
- **Messages.jsx**: Changed the audio waveform background from colored backgrounds to `"transparent"` so the waveform integrates seamlessly with the chat bubble's existing background color

This allows the audio waveform to inherit the chat bubble's background color naturally, creating a more polished WhatsApp-like appearance.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 70`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6304e87487ee4cf28bd4dcd05d5d3a36/pixel-studio)

👀 [Preview Link](https://6304e87487ee4cf28bd4dcd05d5d3a36-pixel-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6304e87487ee4cf28bd4dcd05d5d3a36</projectId>-->
<!--<branchName>pixel-studio</branchName>-->