### PR TITLE
Add bubble variant for audio player in chat messages

### DIFF
--- a/frontend/src/components/AudioWaveform.jsx
+++ b/frontend/src/components/AudioWaveform.jsx
@@ -79,7 +79,7 @@ export const LiveWaveform = ({ stream, height = 36, color = '#2563eb', bg = '#e5
   )
 }
 
-export const PlaybackWaveform = ({ src, peaks, height = 28, color = '#2563eb', bg = '#e5e7eb' }) => {
+export const PlaybackWaveform = ({ src, peaks, height = 28, color = '#2563eb', bg = '#e5e7eb', variant = 'default', playBg }) => {
   const canvasRef = useRef(null)
   const audioRef = useRef(null)
   const rafRef = useRef(null)
@@ -272,6 +272,41 @@ export const PlaybackWaveform = ({ src, peaks, height = 28, color = '#2563eb', b
 
   const iconColor = (typeof color === 'string' && color.toLowerCase() === '#ffffff') || color === 'white' ? '#2563eb' : '#ffffff'
   const timeColor = (typeof color === 'string' && color.toLowerCase() === '#ffffff') || color === 'white' ? 'rgba(255,255,255,0.85)' : 'rgba(55,65,81,0.8)'
+  const playBgColor = playBg || (((typeof color === 'string' && color.toLowerCase() === '#ffffff') || color === 'white') ? '#1d4ed8' : '#2563eb')
+
+  if (variant === 'bubble') {
+    return (
+      <div className="w-full flex items-center gap-3">
+        <audio ref={audioRef} src={src} preload="metadata" crossOrigin="anonymous" />
+        <button
+          onClick={() => {
+            const a = audioRef.current
+            if (!a) return
+            if (a.paused) a.play(); else a.pause()
+          }}
+          className="w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0"
+          style={{ backgroundColor: playBgColor, color: '#ffffff' }}
+          aria-label="Reproduzir/Pausar áudio"
+        >
+          {isPlaying ? <Pause size={16} /> : <Play size={16} />}
+        </button>
+
+        <div className="flex-1 relative select-none" style={{ height }}
+          onClick={(e) => {
+            const a = audioRef.current
+            const canvas = canvasRef.current
+            if (!a || !canvas || !duration) return
+            const rect = canvas.getBoundingClientRect()
+            const x = e.clientX - rect.left
+            const p = Math.min(1, Math.max(0, x / rect.width))
+            a.currentTime = p * duration
+          }}
+        >
+          <canvas ref={canvasRef} style={{ width: '100%', height: `${height}px`, display: 'block' }} />
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="w-full flex items-center gap-2">

--- a/frontend/src/pages/Messages.jsx
+++ b/frontend/src/pages/Messages.jsx
@@ -1085,13 +1085,13 @@ const Messages = () => {
                   )}
 
                   <div className={`flex px-3 ${message.senderId === user.id ? 'justify-end' : 'justify-start'}`}>
-                    <div className={`max-w-xs lg:max-w-md px-3 py-2 rounded-2xl overflow-hidden whitespace-pre-wrap break-words ${
+                    <div className={`max-w-xs lg:max-w-md ${message.messageType === 'audio' ? 'px-3 py-2 rounded-full' : 'px-3 py-2 rounded-2xl'} overflow-hidden whitespace-pre-wrap break-words ${
                       message.senderId === user.id
                         ? 'bg-vibe-blue text-white'
                         : 'bg-gray-200 text-gray-900'
                     }`}>
                       {message.messageType === 'audio' ? (
-                        <PlaybackWaveform src={message.mediaUrl} peaks={message.waveformPeaks} height={32} color={message.senderId === user.id ? '#ffffff' : '#2563eb'} bg="transparent" />
+                        <PlaybackWaveform variant="bubble" src={message.mediaUrl} peaks={message.waveformPeaks} height={28} color={message.senderId === user.id ? '#ffffff' : '#2563eb'} playBg={message.senderId === user.id ? '#1d4ed8' : '#2563eb'} bg="transparent" />
                       ) : message.messageType === 'image' ? (
                         <img src={message.mediaUrl} alt="imagem" className="max-w-[240px] rounded-lg" />
                       ) : message.messageType === 'video' ? (


### PR DESCRIPTION
## Purpose

The user wants to redesign the audio player in the chat interface to match a specific visual style they have in mind. They're looking to transform the current audio player to look exactly like a reference image they plan to share, focusing on improving the chat's audio message appearance.

## Code changes

- **AudioWaveform component**: Added new `bubble` variant to `PlaybackWaveform` component with `variant` and `playBg` props
- **Bubble variant layout**: Created a new rendering mode with circular play button (9x9, rounded-full) and streamlined waveform display
- **Messages page**: Updated audio message styling to use rounded-full container instead of rounded-2xl for audio messages
- **Audio player integration**: Applied the new bubble variant to chat audio messages with appropriate color theming based on sender (user vs others)
- **Responsive design**: Maintained flexible layout with proper gap spacing and color contrast for different message typesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 72`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6304e87487ee4cf28bd4dcd05d5d3a36/pixel-realm)

👀 [Preview Link](https://6304e87487ee4cf28bd4dcd05d5d3a36-pixel-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6304e87487ee4cf28bd4dcd05d5d3a36</projectId>-->
<!--<branchName>pixel-realm</branchName>-->