### PR TITLE
Improve audio player styling in messenger

### DIFF
--- a/frontend/src/pages/Messages.jsx
+++ b/frontend/src/pages/Messages.jsx
@@ -1085,7 +1085,9 @@ const Messages = () => {
                   )}
 
                   <div className={`flex px-3 ${message.senderId === user.id ? 'justify-end' : 'justify-start'}`}>
-                    <div className={`max-w-xs lg:max-w-md ${message.messageType === 'audio' ? 'px-3 py-2 rounded-full' : 'px-3 py-2 rounded-2xl'} overflow-hidden whitespace-pre-wrap break-words ${
+                    <div className={`${message.messageType === 'audio'
+                      ? 'w-[78%] sm:w-[70%] max-w-full px-3 py-2 rounded-full'
+                      : 'max-w-xs lg:max-w-md px-3 py-2 rounded-2xl'} overflow-hidden whitespace-pre-wrap break-words ${
                       message.senderId === user.id
                         ? 'bg-vibe-blue text-white'
                         : 'bg-gray-200 text-gray-900'


### PR DESCRIPTION
## Purpose
The user wanted to improve the audio player appearance in the messenger to make it more stylish and proportional. They noticed that when audio messages are sent, the player appears "chubby, flattened, and disproportional" compared to what's seen on social media platforms. The goal was to create a modern, longer audio player that maintains proper proportions when displayed in messages.

## Code changes
- Modified the audio message container styling in `Messages.jsx`
- Changed audio player width from fixed `max-w-xs lg:max-w-md` to responsive `w-[78%] sm:w-[70%] max-w-full`
- Maintained existing padding and rounded styling for audio messages
- Preserved original styling for non-audio messages
- Updated conditional className logic to handle the new responsive audio player dimensionsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 73`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6304e87487ee4cf28bd4dcd05d5d3a36/echo-haven)

👀 [Preview Link](https://6304e87487ee4cf28bd4dcd05d5d3a36-echo-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6304e87487ee4cf28bd4dcd05d5d3a36</projectId>-->
<!--<branchName>echo-haven</branchName>-->