### PR TITLE
Fix friendship system Pydantic validation errors

### DIFF
--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -41,6 +41,8 @@ class FriendWithUser(BaseModel):
     user_info: UserBasicInfo
     mutual_friends_count: int = 0
 
+    model_config = ConfigDict(from_attributes=True)
+
 # Função helper para verificar se existe amizade
 def get_friendship_between_users(db: Session, user1_id: int, user2_id: int) -> Optional[Friendship]:
     return db.query(Friendship).filter(

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -9,7 +9,7 @@ from ..models.user import User
 from ..models.friendship import Friendship
 from ..models.notification import Notification
 from .auth import get_current_user
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 router = APIRouter()
 

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -339,7 +339,7 @@ async def accept_friend_request(
     except Exception as e:
         print(f"WebSocket send error in accept_friend_request: {e}")
 
-    return friendship
+    return FriendshipResponse.model_validate(friendship, from_attributes=True)
 
 @router.put("/requests/{friendship_id}/reject")
 async def reject_friend_request(

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -435,7 +435,7 @@ def get_user_friends(
             mutual_count = count_mutual_friends(db, current_user.id, friend_id)
 
             result.append(FriendWithUser(
-                friendship=friendship,
+                friendship=FriendshipResponse.model_validate(friendship, from_attributes=True),
                 user_info=UserBasicInfo(
                     id=friend_user.id,
                     username=friend_user.username,

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -115,7 +115,7 @@ async def send_friend_request(
         if existing_friendship.status == "pending":
             # Se já existe um pedido enviado por mim, tornar idempotente
             if getattr(existing_friendship, 'user_id', None) == current_user.id and getattr(existing_friendship, 'friend_id', None) == request.friend_id:
-                return existing_friendship
+                return FriendshipResponse.model_validate(existing_friendship, from_attributes=True)
             # Se existe um pedido inverso (o outro usuário me enviou), aceitar automaticamente
             if getattr(existing_friendship, 'user_id', None) == request.friend_id and getattr(existing_friendship, 'friend_id', None) == current_user.id:
                 existing_friendship.status = "accepted"

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -155,7 +155,7 @@ async def send_friend_request(
                 except Exception:
                     pass
 
-                return existing_friendship
+                return FriendshipResponse.model_validate(existing_friendship, from_attributes=True)
 
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -25,9 +25,8 @@ class FriendshipResponse(BaseModel):
     initiated_by: int
     created_at: datetime
     updated_at: Optional[datetime]
-    
-    class Config:
-        orm_mode = True
+
+    model_config = ConfigDict(from_attributes=True)
 
 class UserBasicInfo(BaseModel):
     id: int

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -270,7 +270,7 @@ def get_sent_friend_requests(
         mutual_count = count_mutual_friends(db, current_user.id, fid) if fid else 0
 
         result.append(FriendWithUser(
-            friendship=friendship,
+            friendship=FriendshipResponse.model_validate(friendship, from_attributes=True),
             user_info=UserBasicInfo(
                 id=target_user.id if target_user else None,
                 username=target_user.username if target_user else '',

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -239,7 +239,7 @@ def get_received_friend_requests(
         mutual_count = count_mutual_friends(db, current_user.id, fid) if fid else 0
 
         result.append(FriendWithUser(
-            friendship=friendship,
+            friendship=FriendshipResponse.model_validate(friendship, from_attributes=True),
             user_info=UserBasicInfo(
                 id=requester.id if requester else None,
                 username=requester.username if requester else '',

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -33,9 +33,8 @@ class UserBasicInfo(BaseModel):
     username: str
     display_name: Optional[str]
     avatar_url: Optional[str]
-    
-    class Config:
-        orm_mode = True
+
+    model_config = ConfigDict(from_attributes=True)
 
 class FriendWithUser(BaseModel):
     friendship: FriendshipResponse

--- a/backend/app/api/friendships.py
+++ b/backend/app/api/friendships.py
@@ -218,7 +218,7 @@ async def send_friend_request(
     except Exception as e:
         print(f"WebSocket send error in send_friend_request: {e}")
 
-    return new_friendship
+    return FriendshipResponse.model_validate(new_friendship, from_attributes=True)
 
 @router.get("/requests/received", response_model=List[FriendWithUser])
 def get_received_friend_requests(

--- a/frontend/src/components/BottomNavigation.jsx
+++ b/frontend/src/components/BottomNavigation.jsx
@@ -77,10 +77,15 @@ const BottomNavigation = () => {
     }
   }, [lastMessage])
 
-  // Carregar contadores ao montar
+  // Carregar contadores ao montar e fazer polling para robustez mesmo sem WS
   useEffect(() => {
     loadUnreadCounts()
     loadFriendCounts()
+
+    const iv = setInterval(() => {
+      loadFriendCounts()
+    }, 15000)
+    return () => clearInterval(iv)
   }, [user?.id])
 
   const navItems = [

--- a/frontend/src/components/FriendshipButton.jsx
+++ b/frontend/src/components/FriendshipButton.jsx
@@ -3,9 +3,11 @@ import { UserPlus, UserCheck, Clock, UserX } from 'lucide-react'
 import { friendshipsAPI } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
 import useWebSocket from '../hooks/useWebSocket'
+import { useNavigate } from 'react-router-dom'
 
-const FriendshipButton = ({ userId, username, onStatusChange, className = '' }) => {
+const FriendshipButton = ({ userId, username, onStatusChange, className = '', showDecisionButtons = true }) => {
   const { user: currentUser } = useAuth()
+  const navigate = useNavigate()
   const [status, setStatus] = useState('none') // none, request_sent, request_received, friends, self
   const [loading, setLoading] = useState(false)
   const { lastMessage } = useWebSocket()
@@ -286,6 +288,16 @@ const FriendshipButton = ({ userId, username, onStatusChange, className = '' }) 
   const Icon = config.icon
 
   if (status === 'request_received') {
+    if (!showDecisionButtons) {
+      return (
+        <button
+          onClick={() => navigate('/friends')}
+          className={`px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 hover:bg-yellow-200 ${className}`}
+        >
+          Pedido pendente
+        </button>
+      )
+    }
     return (
       <div className={`flex items-center gap-2 ${className}`}>
         <button

--- a/frontend/src/pages/Friends.jsx
+++ b/frontend/src/pages/Friends.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { friendshipsAPI } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
 import FriendshipButton from '../components/FriendshipButton'
+import useWebSocket from '../hooks/useWebSocket'
 
 const Friends = () => {
   const navigate = useNavigate()
@@ -15,6 +16,7 @@ const Friends = () => {
   const [receivedRequests, setReceivedRequests] = useState([])
   const [sentRequests, setSentRequests] = useState([])
   const [error, setError] = useState('')
+  const { lastMessage } = useWebSocket()
 
   useEffect(() => {
     if (currentUser?.id) {
@@ -114,6 +116,32 @@ const Friends = () => {
   const handleProfileClick = (username) => {
     navigate(`/profile/id/${username}`)
   }
+
+  // Atualizar pela chegada de eventos WebSocket relevantes
+  useEffect(() => {
+    if (!lastMessage) return
+    const isFriendEvent = lastMessage.type === 'friendship_update' ||
+      (lastMessage.type === 'notification' && (lastMessage.data?.type === 'friend_request' || lastMessage.data?.type === 'friend_accepted'))
+    if (!isFriendEvent) return
+    if (activeTab === 'friends') {
+      loadFriends()
+    } else if (activeTab === 'requests') {
+      loadRequests()
+    }
+  }, [lastMessage, activeTab])
+
+  // Polling a cada 15s para garantir atualização mesmo sem WS
+  useEffect(() => {
+    if (!currentUser?.id) return
+    const iv = setInterval(() => {
+      if (activeTab === 'friends') {
+        loadFriends()
+      } else if (activeTab === 'requests') {
+        loadRequests()
+      }
+    }, 15000)
+    return () => clearInterval(iv)
+  }, [activeTab, currentUser?.id])
 
   const tabs = [
     {

--- a/frontend/src/pages/Visits.jsx
+++ b/frontend/src/pages/Visits.jsx
@@ -177,6 +177,7 @@ const Visits = () => {
                 <FriendshipButton
                   userId={visitor.id}
                   username={visitor.username}
+                  showDecisionButtons={false}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Purpose

The user reported multiple issues with the friendship system:
- Friendship requests not displaying correctly in the "friends" section
- Pydantic validation errors when handling friendship data
- Accept/reject buttons appearing in the "visits" section instead of "friends"
- Overall friendship functionality not working properly

## Code changes

**Backend (friendships.py):**
- Updated Pydantic models to use `model_config = ConfigDict(from_attributes=True)` instead of deprecated `Config.orm_mode = True`
- Added proper model validation using `FriendshipResponse.model_validate()` with `from_attributes=True` for all friendship returns
- Fixed validation errors by ensuring consistent data serialization across all friendship endpoints

**Frontend:**
- Modified `FriendshipButton` component to accept `showDecisionButtons` prop to control when accept/reject buttons are shown
- Updated Visits page to use `showDecisionButtons={false}` so friendship decisions only appear in Friends section
- Added WebSocket event handling and polling to Friends page for real-time updates
- Enhanced BottomNavigation with periodic friend count updates for better reliability

These changes resolve the Pydantic validation errors and ensure friendship requests are properly managed in the correct UI sections.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 87`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0ac154c9829640029d300eab02ca50a9/neon-garden)

👀 [Preview Link](https://0ac154c9829640029d300eab02ca50a9-neon-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0ac154c9829640029d300eab02ca50a9</projectId>-->
<!--<branchName>neon-garden</branchName>-->